### PR TITLE
new fuse logic and add inverse relations

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -279,6 +279,23 @@ def fz_data_action(showtype, id):
     else:
         return {}
 
+@app.route("/fz/inverserel/<string:uuid>", methods = ["GET", "POST"])
+def fz_work_inverse_relation_uris_action(uuid):
+    from sparql.chronicle import Chronicle
+    fz = Chronicle()
+    return {"instanceOf" : fz.query_instanceOf_uris_of_fz_work(uuid), "itemOf" : fz.query_itemOf_uris_of_fz_work(uuid)}
+
+@app.route("/fz/inversedata/<string:inversetype>/<string:uuid>", methods = ["GET"])
+def fz_work_inverse_relation_data_action(inversetype, uuid):
+    from sparql.chronicle import Chronicle
+    fz = Chronicle()
+    if str.lower(inversetype) == "instance":
+        return fz.query_ecnu_for_instance_data_of_work(uuid)
+    elif str.lower(inversetype) == "item":
+        return fz.query_ecnu_for_item_data_of_work(uuid)
+    else:
+        return {}
+
 @app.route("/uuid/produce/<string:showtype>/<string:uuid>", methods = ["GET"])
 def produce_data_from_uuid_action(showtype, uuid):
     from sparql.sparql import fzwc_produce_data_select_from_uuid, fzwc_produce_data_construct_from_uuid

--- a/server.py
+++ b/server.py
@@ -5,7 +5,7 @@ import os
 app = Flask('Yunan Products')
 
 def get_port():
-    with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), r"conf\port")) as f:
+    with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), r"conf", r"port")) as f:
         return int(f.readline())
 
 port_conf = get_port()

--- a/sparql/chronicle.py
+++ b/sparql/chronicle.py
@@ -7,6 +7,14 @@ from SPARQLWrapper import SPARQLWrapper, JSON, RDFXML
 base_fzwc_fz_uri = "http://data.fzwc.online/resource/fz/"
 base_ecnu_fz_uri = "http://fangzhi.ecnu.edu.cn/entity/work/"
 
+base_ecnu_instance_uri = "http://fangzhi.ecnu.edu.cn/entity/instance/"
+base_ecnu_item_uri = "http://fangzhi.ecnu.edu.cn/entity/item/"
+
+rdfs = "http://www.w3.org/2000/01/rdf-schema#"
+rdf  = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+shl  = "http://www.library.sh.cn/ontology/"
+bf   = "http://id.loc.gov/ontologies/bibframe/"
+
 class Chronicle:
     def __init__(self, output_type = JSON):
         self.ecnu_sparql_server = SPARQLWrapper(Databases.ecnu_server)
@@ -76,13 +84,27 @@ class Chronicle:
             
             self.fusefactory.fuse_append(acc, bnode_data)
 
+    def __query_ecnu_fz_data_from_uri(self, uri, deprecated_props = None):
+        def get_rid_of_deprecated_props(dict_data, keys):
+            if keys is None:
+                return dict_data
+            else:
+                for k in keys:
+                    if k in dict_data:
+                        del dict_data[k]
+                return dict_data
+
+        json_data = self.__query_ecnu_for_property_and_value(uri)
+        updated_data_value = get_rid_of_deprecated_props(list(json_data.values())[0], deprecated_props)
+        json_data = {uri: updated_data_value}
+        bnodes = FuseJson.get_blank_nodes(updated_data_value)
+        self.__fuse_append(json_data, bnodes)
+        return json_data
+
     def query_ecnu_fz_data(self, id):
         ecnu_fz_uri = Chronicle.ecnu_fz_uri(id)
         if len(ecnu_fz_uri) > 0:
-            json_data = self.__query_ecnu_for_property_and_value(ecnu_fz_uri)
-            bnodes = FuseJson.get_blank_nodes(list(json_data.values())[0])
-            self.__fuse_append(json_data, bnodes)
-            return json_data
+            return self.__query_ecnu_fz_data_from_uri(ecnu_fz_uri)
         else:
             return {"error" : "no uri found"}
 
@@ -113,20 +135,35 @@ class Chronicle:
         return self.__query_fz_data(ecnu_fz_uri, fzwc_fz_uri)
 
     def __query_fz_data(self, ecnu_fz_uri, fzwc_fz_uri):
+        """ During fuse fz work in ecnu and fz in fzwc,
+            first get rid of 3 properties including their sub properties in ecnu fz work
+        """
+        deprecated_prop = {
+            f"{bf}title",
+            f"{bf}contribution",
+            f"{bf}geographicCoverage"
+        }
         try:
             # 1. Get all nodes
             fz_data_from_fzwc = self.__query_fzwc_for_property_and_value(fzwc_fz_uri)
 
             if ecnu_fz_uri:
-                fz_data_from_ecnu = self.__query_ecnu_for_property_and_value(ecnu_fz_uri)
+                fz_data_from_ecnu = self.__query_ecnu_fz_data_from_uri(ecnu_fz_uri, deprecated_prop)
                 if len(fz_data_from_ecnu) > 0:
-                    # 2. Fuse ecnu data into fzwc data, consume fzwc first for the samme properties
-                    fused_data, bnodes_after_fuse = self.fusefactory.fuse(fz_data_from_fzwc, fz_data_from_ecnu)
+                    # 2. Fuse ecnu data into fzwc data
+                    # because we have already get rid of duplicated properties in ecnu,
+                    # so we just update fzwc fz data into ecnu fz date, bnodes are at the same level with the fused fz data
+                    # (btw, ecnu and fzwc use different system, so their keys will not same)
+                    fused_fz_data = list(fz_data_from_fzwc.values())[0]
+                    for k, v in fz_data_from_ecnu.items():
+                        if k == ecnu_fz_uri:
+                            fused_fz_data.update(v)
+                            fused_fz_data = {fzwc_fz_uri: fused_fz_data}
+                        else:
+                            # append bnodes
+                            fused_fz_data.update({k: v})
 
-                    # 3. Append bnodes
-                    self.__fuse_append(fused_data, bnodes_after_fuse)
-
-                    return fused_data
+                    return fused_fz_data
             else:
                 # 2. not data from ecnu, just return fzwc data
                 return fz_data_from_fzwc
@@ -136,9 +173,43 @@ class Chronicle:
         except Exception as e:
             return {"error" : f"wrong fz data received. detail msg: {str(e)}"}
 
+    def __qurey_inverse_relation_uris(self, property, which_uuid):
+        clause = f"""
+            select ?uri
+            WHERE {{
+                ?uri {property} <{base_ecnu_fz_uri}{which_uuid}> .
+            }}
+        """
+
+        self.ecnu_sparql_server.setQuery(clause)
+        self.ecnu_sparql_server.setReturnFormat(JSON)
+        results = self.ecnu_sparql_server.query().convert()
+
+        uris = []
+        for data in results["results"]["bindings"]:
+            uris.append(data["uri"]["value"])
+        return uris
+
+    def query_itemOf_uris_of_fz_work(self, which_uuid):
+        return [uri.rsplit("/", 1)[-1] for uri in self.__qurey_inverse_relation_uris("bf:itemOf", which_uuid)]
+
+    def query_instanceOf_uris_of_fz_work(self, which_uuid):
+        return [uri.rsplit("/", 1)[-1] for uri in self.__qurey_inverse_relation_uris("bf:instanceOf", which_uuid)]
+
+    def query_ecnu_for_instance_data_of_work(self, instance_uuid):
+        instance_uri = f"{base_ecnu_instance_uri}{instance_uuid}"
+        return self.__query_ecnu_fz_data_from_uri(instance_uri)
+
+    def query_ecnu_for_item_data_of_work(self, item_uuid):
+        item_uri = f"{base_ecnu_item_uri}{item_uuid}"
+        return self.__query_ecnu_fz_data_from_uri(item_uri)
+
+
 if __name__ == "__main__":
     load_sparql_internal_data()
 
-    fz = Chronicle(RDFXML)
-    #Printjson(fz.query_fz_data_from_id(39))
-    print(fz.query_fz_data_from_id(39))
+    fz = Chronicle(JSON)
+    Printjson(fz.query_fz_data_from_id(17))
+    #Printjson(fz.query_instanceOf_uris_of_fz_work("5f5e8d47f16a407281fdd544093f35e2"))
+    #Printjson(fz.query_ecnu_for_inverse_relation_data_of_work("http://fangzhi.ecnu.edu.cn/entity/instance/be2c5342aa3742ec99703fdb8972abc4"))
+    #Printjson(fz.query_ecnu_for_inverse_relation_data_of_work(fz.query_instanceOf_uris_of_fz_work("5f5e8d47f16a407281fdd544093f35e2")[0]))

--- a/sparql/fusejson.py
+++ b/sparql/fusejson.py
@@ -1,6 +1,8 @@
 class FuseJson:
     @staticmethod
     def fuse(to_data, from_data):
+        """ deprecated
+        """
         to_props_set = set(list(to_data.values())[0].keys())
         from_props_set = set(list(from_data.values())[0].keys())
         intersection_props = to_props_set.intersection(from_props_set)

--- a/sparql/preload.py
+++ b/sparql/preload.py
@@ -29,7 +29,7 @@ def load_from_txt():
         with open(fz_uuid, "r", encoding = "utf8") as fz:
             for line in fz.readlines():
                 id, _, _, _, internal_uuid, external_uuid = line.split(";", 5)
-                fz_cache[int(id)] = (internal_uuid, external_uuid.strip())
+                fz_cache[int(id)] = (internal_uuid, external_uuid.strip(" ;\n"))
 
     load_wc()
     load_fz()

--- a/util.py
+++ b/util.py
@@ -15,7 +15,7 @@ timeout_secound = 30
 
 ## data server ip
 def get_data_server():
-    with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), r"conf\datasrv")) as f:
+    with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), r"conf", r"datasrv")) as f:
         return f.readline()
 data_server = get_data_server() # "http://47.97.124.135" # "http://localhost:2345"
 


### PR DESCRIPTION
1. new fuse logic
    because ecnu and fzwc uses different system, so same properties in both side is not the same string. so we delete 3 properties  below in ecnu before fusing.
    `bf:title`, `bf:contribution`, `bf:geographicCoverage`
2. add inverse relations for ecnu fz work - itemOf and instanceOf